### PR TITLE
Migrate to org reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,5 +4,7 @@ on:
     types: [opened, ready_for_review, reopened]
 jobs:
   claude-review:
+    # Dependabot cannot grant id-token: write to the reusable (startup_failure).
+    if: github.actor != 'dependabot[bot]'
     uses: PSD401/.github/.github/workflows/reusable-claude-review.yml@main
     secrets: inherit

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,11 @@ on:
     types: [opened, ready_for_review, reopened]
 jobs:
   claude-review:
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write # reusable's claude-code-action OIDC exchange; caller must grant (org default is read-only)
     # Dependabot cannot grant id-token: write to the reusable (startup_failure).
     if: github.actor != 'dependabot[bot]'
     uses: PSD401/.github/.github/workflows/reusable-claude-review.yml@main

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,57 +1,8 @@
-name: Claude Code Review
-
+name: Claude Review
 on:
   pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
-
+    types: [opened, ready_for_review, reopened]
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
-
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-
+    uses: PSD401/.github/.github/workflows/reusable-claude-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What changed

- Replaced the repository-local implementation in `.github/workflows/claude-code-review.yml` with a thin caller of `PSD401/.github/.github/workflows/reusable-claude-review.yml@main`.
- The caller inherits secrets and explicitly grants `contents: read`, `pull-requests: read`, `issues: read`, and `id-token: write`, because the called workflow cannot elevate beyond its caller's permissions.
- Added `if: github.actor != 'dependabot[bot]'` at the caller boundary. Dependabot-authored runs cannot provide the needed credentials/permission grant, so their Claude review is intentionally skipped instead of failing during reusable-workflow startup.
- Added `.github/dependabot.yml` with weekly GitHub Actions dependency checks.

## Intentional behavior changes

1. Claude review activity types change from `[opened, synchronize]` to `[opened, ready_for_review, reopened]`.
2. Claude review no longer runs automatically after every commit pushed to an existing PR. Maintainers can intentionally retrigger it at the current head through draft-to-ready or close-to-reopen.
3. Dependabot-authored PRs intentionally skip this advisory Claude review.
4. Review implementation, prompt, model selection, and action pins move to the organization-owned reusable workflow at `@main`.

OpenWiki is outside this PR's scope; no OpenWiki file or behavior is removed or changed.

## VERIFICATION EVIDENCE

Verified from base `e776864a249187203e4db9c21558f6be1da97fbf` through exact head `28c43393cea2693f7b08a5f0445adb4bd9923ccd`.

- `git rev-parse HEAD` — `28c43393cea2693f7b08a5f0445adb4bd9923ccd`.
- `git diff --name-status e776864a249187203e4db9c21558f6be1da97fbf 28c43393cea2693f7b08a5f0445adb4bd9923ccd` — only `.github/dependabot.yml` (added) and `.github/workflows/claude-code-review.yml` (modified).
- `git diff --check e776864a249187203e4db9c21558f6be1da97fbf 28c43393cea2693f7b08a5f0445adb4bd9923ccd` — pass, no output.
- `docker run --rm -i rhysd/actionlint:1.7.7 - < .github/workflows/claude-code-review.yml` — pass, 0 findings.
- Ruby `YAML.safe_load_file(..., aliases: true)` on `.github/dependabot.yml` and `.github/workflows/claude-code-review.yml` — pass for both files.
- Current exact-head CI build and all three CodeQL checks are successful.
- A `ready_for_review` retrigger created current-head run `31863707898`. Its wrapper reports success, but the action log explicitly reports a workflow-validation skip because the modified caller is not identical to the default-branch copy; no Claude review comment was produced. The ancestor migration run `31844030505` concluded `startup_failure`. This remains a pre-merge blocker for this human-authored PR.

No application code, tests, lint rules, or product CI workflow is changed. No test or lint task is removed, skipped, deselected, or disabled; there is therefore no disablement TODO.

---
Part of Phase 3 standard-CI rollout — see psd-dev-standards.
